### PR TITLE
Add: info about "SICP support for Racket"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 * Racket
 * Rackunit (`raco pkg install rackunit`)
+* [SICP Support for DrRacket](https://docs.racket-lang.org/sicp-manual/index.html) (`raco pkg install sicp`)
 * Make
 
 ### Using

--- a/sicp/chapter1/02.rkt
+++ b/sicp/chapter1/02.rkt
@@ -1,6 +1,6 @@
-#lang racket/base
+#lang sicp
 
-(require rackunit)
+(#%require rackunit)
 
 (define solution
   (/ (+ 5
@@ -9,7 +9,9 @@
            (- 3
               (+ 6
                  (/ 4
-                    5)))))
+                    (dec
+                     (inc
+                      5)))))))
      (* 3
         (- 6
            2)


### PR DESCRIPTION
Add info about special dialect for SICP learners.
Change the example to use a '#lang sicp`.